### PR TITLE
Fixed the priorities of the conda channenls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /
 RUN curl -OJLs https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
 RUN bash Miniconda3-latest-Linux-x86_64.sh -p /miniconda -b
 ENV PATH=${PATH}:/miniconda/bin
-RUN conda update -y conda && conda install -y -c conda-forge -c hi2p-perim \
+RUN conda update -y conda && conda install -y -c hi2p-perim -c conda-forge \
     python=3.7 \
     cmake \
     ninja \

--- a/environment_linux.yml
+++ b/environment_linux.yml
@@ -1,7 +1,9 @@
 name: lm3_dev
 channels:
-  - conda-forge
+  # hi2p-perim channel must have higher priority
+  # because some packages might have the same names.
   - hi2p-perim
+  - conda-forge
 dependencies:
   - python=3.7
   - cmake

--- a/environment_win.yml
+++ b/environment_win.yml
@@ -1,7 +1,9 @@
 name: lm3_dev
 channels:
-  - conda-forge
+  # hi2p-perim channel must have higher priority
+  # because some packages might have the same names.
   - hi2p-perim
+  - conda-forge
 dependencies:
   - python=3.7
   - cmake


### PR DESCRIPTION
This PR avoids to install official cereal package that seemingly doesn't install *config.cmake files.