### PR TITLE
Timer

### DIFF
--- a/include/lm/timer.h
+++ b/include/lm/timer.h
@@ -1,0 +1,49 @@
+/*
+    Lightmetrica - Copyright (c) 2019 Hisanari Otsu
+    Distributed under MIT license. See LICENSE file for details.
+*/
+
+#pragma once
+
+#include "component.h"
+#include <chrono>
+
+LM_NAMESPACE_BEGIN(LM_NAMESPACE)
+LM_NAMESPACE_BEGIN(timer)
+
+/*!
+    \addtogroup timer
+    @{
+*/
+
+/*!
+    \brief Scoped Timer for elapsed time
+
+    \rst
+    This class provides a compact way to time code using the RAII idiom:
+    Resource Acquisition Is Initialization
+    \endrst
+*/
+class ScopedTimer : public Component {
+private:
+    std::chrono::high_resolution_clock::time_point start;
+public:
+    /*!
+        \brief Timer initialisation at the time of object creation
+    */
+    ScopedTimer():start(std::chrono::high_resolution_clock::now()){}
+
+    /*!
+        \brief elapsed time since object creation in seconds
+    */
+   virtual Float now() const{
+       return std::chrono::duration<Float>(std::chrono::high_resolution_clock::now()-start).count();
+   }
+};
+
+/*!
+    @}
+*/
+
+LM_NAMESPACE_END(timer)
+LM_NAMESPACE_END(LM_NAMESPACE)

--- a/plugin/volume_openvdb/renderer_volraycast.cpp
+++ b/plugin/volume_openvdb/renderer_volraycast.cpp
@@ -12,6 +12,7 @@
 #include <lm/phase.h>
 #include <lm/scheduler.h>
 #include <lm/path.h>
+#include <lm/timer.h>
 
 LM_NAMESPACE_BEGIN(LM_NAMESPACE)
 
@@ -56,7 +57,7 @@ public:
     virtual Json render() const override {
         film_->clear();
         const auto size = film_->size();
-
+        timer::ScopedTimer st;
         // Compute colors for each pixel
         sched_->run([&](long long pixelIndex, long long, int) {
             const int x = int(pixelIndex % size.w);
@@ -106,7 +107,7 @@ public:
             film_->set_pixel(x, y, L);
         });
 
-        return {};
+        return { {"elapsed", st.now()} };
     }
 };
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,6 +52,7 @@ set(_HEADER_FILES
     "${_INCLUDE_DIR}/volume.h"
     "${_INCLUDE_DIR}/path.h"
     "${_INCLUDE_DIR}/bidir.h"
+    "${_INCLUDE_DIR}/timer.h"
     )
 set(_SOURCE_FILES 
     "${_SOURCE_DIR}/component.cpp"

--- a/src/renderer/renderer_bdpt.cpp
+++ b/src/renderer/renderer_bdpt.cpp
@@ -11,6 +11,7 @@
 #include <lm/scheduler.h>
 #include <lm/bidir.h>
 #include <lm/debug.h>
+#include <lm/timer.h>
 
 // Poll mutated paths
 #define BDPT_POLL_PATHS 0
@@ -65,6 +66,7 @@ public:
         scene_->require_renderable();
         film_->clear();
         const auto size = film_->size();
+        timer::ScopedTimer st;
 
         // Execute parallel process
         const auto processed = sched_->run([&](long long, long long sample_index, int threadid) {
@@ -115,7 +117,7 @@ public:
         // Rescale film
         film_->rescale(Float(size.w * size.h) / processed);
 
-        return { {"processed", processed} };
+        return { {"processed", processed}, {"elapsed", st.now()} };
     }
 };
 
@@ -130,6 +132,7 @@ public:
         scene_->require_renderable();
         film_->clear();
         const auto size = film_->size();
+        timer::ScopedTimer st;
 
         // Execute parallel process
         const auto processed = sched_->run([&](long long, long long, int threadid) {
@@ -190,7 +193,7 @@ public:
         // Rescale film
         film_->rescale(Float(size.w * size.h) / processed);
 
-        return { {"processed", processed} };
+        return { {"processed", processed}, {"elapsed", st.now()} };
     }
 };
 
@@ -205,6 +208,7 @@ public:
         scene_->require_renderable();
         film_->clear();
         const auto size = film_->size();
+        timer::ScopedTimer st;
 
         // Execute parallel process
         const auto processed = sched_->run([&](long long, long long sample_index, int threadid) {
@@ -277,7 +281,7 @@ public:
         // Rescale film
         film_->rescale(Float(size.w * size.h) / processed);
 
-        return { {"processed", processed} };
+        return { {"processed", processed}, {"elapsed", st.now()} };
     }
 };
 
@@ -327,6 +331,7 @@ public:
         scene_->require_renderable();
         film_->clear();
         const auto size = film_->size();
+        timer::ScopedTimer st;
 
         // Execute parallel process
         const auto processed = sched_->run([&](long long, long long sample_index, int threadid) {
@@ -401,7 +406,7 @@ public:
         }
         #endif
 
-        return { {"processed", processed} };
+        return { {"processed", processed}, {"elapsed", st.now()} };
     }
 };
 

--- a/src/renderer/renderer_bdptopt.cpp
+++ b/src/renderer/renderer_bdptopt.cpp
@@ -10,6 +10,7 @@
 #include <lm/film.h>
 #include <lm/scheduler.h>
 #include <lm/path.h>
+#include <lm/timer.h>
 
 LM_NAMESPACE_BEGIN(LM_NAMESPACE)
 
@@ -446,6 +447,7 @@ public:
         scene_->require_renderable();
         film_->clear();
         const auto size = film_->size();
+        timer::ScopedTimer st;
 
 
         // Execute parallel process
@@ -502,7 +504,7 @@ public:
         }
         #endif
 
-        return { {"processed", processed} };
+        return { {"processed", processed}, {"elapsed", st.now()} };
     }
 };
 

--- a/src/renderer/renderer_lt.cpp
+++ b/src/renderer/renderer_lt.cpp
@@ -10,6 +10,7 @@
 #include <lm/film.h>
 #include <lm/scheduler.h>
 #include <lm/path.h>
+#include <lm/timer.h>
 
 LM_NAMESPACE_BEGIN(LM_NAMESPACE)
 
@@ -50,6 +51,7 @@ public:
         scene_->require_renderable();
         film_->clear();
         const auto size = film_->size();
+        timer::ScopedTimer st;
 
         // Execute parallel process
         const auto processed = sched_->run([&](long long, long long, int threadid) {
@@ -167,7 +169,7 @@ public:
         // Rescale film
         film_->rescale(Float(size.w * size.h) / processed);
 
-        return { {"processed", processed} };
+        return { {"processed", processed}, {"elapsed", st.now()} };
     }
 };
 

--- a/src/renderer/renderer_pt.cpp
+++ b/src/renderer/renderer_pt.cpp
@@ -10,6 +10,7 @@
 #include <lm/film.h>
 #include <lm/scheduler.h>
 #include <lm/path.h>
+#include <lm/timer.h>
 
 LM_NAMESPACE_BEGIN(LM_NAMESPACE)
 
@@ -82,6 +83,7 @@ public:
         // Clear film
         film_->clear();
         const auto size = film_->size();
+        timer::ScopedTimer st;
 
         // Execute parallel process
         const auto processed = sched_->run([&](long long pixel_index, long long, int threadid) {
@@ -309,7 +311,7 @@ public:
             film_->rescale(Float(size.w * size.h) / processed);
         }
 
-        return { {"processed", processed} };
+        return { {"processed", processed}, {"elapsed", st.now()} };
     }
 };
 

--- a/src/renderer/renderer_raycast.cpp
+++ b/src/renderer/renderer_raycast.cpp
@@ -12,6 +12,7 @@
 #include <lm/parallel.h>
 #include <lm/scheduler.h>
 #include <lm/path.h>
+#include <lm/timer.h>
 
 LM_NAMESPACE_BEGIN(LM_NAMESPACE)
 
@@ -65,6 +66,7 @@ public:
 
         film_->clear();
         const auto size = film_->size();
+        timer::ScopedTimer st;
         sched_->run([&](long long index, long long, int) {
             const int x = int(index % size.w);
             const int y = int(index / size.w);
@@ -87,7 +89,7 @@ public:
             }
         });
 
-        return {};
+        return { {"elapsed", st.now()} };
     }
 };
 

--- a/src/renderer/renderer_volpt.cpp
+++ b/src/renderer/renderer_volpt.cpp
@@ -10,6 +10,7 @@
 #include <lm/film.h>
 #include <lm/scheduler.h>
 #include <lm/path.h>
+#include <lm/timer.h>
 
 #define VOLPT_IMAGE_SAMPLING 0
 
@@ -62,6 +63,7 @@ public:
 
         film_->clear();
         const auto size = film_->size();
+        timer::ScopedTimer st;
         const auto processed = sched_->run([&](long long pixel_index, long long sample_index, int threadid) {
             LM_KEEP_UNUSED(sample_index);
 
@@ -183,7 +185,7 @@ public:
         film_->rescale(1_f / processed);
         #endif
 
-        return { {"processed", processed} };
+        return { {"processed", processed}, {"elapsed", st.now()} };
     }
 };
 
@@ -198,6 +200,7 @@ public:
 
         film_->clear();
         const auto size = film_->size();
+        timer::ScopedTimer st;
         const auto processed = sched_->run([&](long long pixel_index, long long sample_index, int threadid) {
             LM_KEEP_UNUSED(sample_index);
 
@@ -360,7 +363,7 @@ public:
         film_->rescale(1_f / processed);
         #endif
 
-        return { {"processed", processed} };
+        return { {"processed", processed}, {"elapsed", st.now()} };
     }
 };
 


### PR DESCRIPTION
This PR adds a minimal way to time processes.
This implementation uses a Scoped timer, usage is as follows:
`timer::Scopedtimer st;
//code
Float elapsed=st.now();`
The Float elapsed here contains the time in seconds elapsed since the initialisation of st.