### PR TITLE
Small bug fix

### DIFF
--- a/src/objloader/objloader_simple.cpp
+++ b/src/objloader/objloader_simple.cpp
@@ -70,7 +70,11 @@ public:
             // ----- Parse group
             else if (command(t, "g", 1)) {
                 t += 1;
-                primitives.emplace_back();
+                // Create a new primitive
+                // If 'g' is defined immediately after 'usemtl', use the last primitive.
+                if (primitives.empty() || !primitives.back().fs.empty()) {
+                    primitives.emplace_back();
+                }
                 primitives.back().material_index = curr_material_index;
             }
 

--- a/src/renderer/renderer_raycast.cpp
+++ b/src/renderer/renderer_raycast.cpp
@@ -80,12 +80,20 @@ public:
                 film_->set_pixel(x, y, glm::abs(sp->geom.n));
             }
             else {
-                const auto R = color_ ? *color_ : path::reflectance(scene_ , *sp);
-                auto C = R ? *R : Vec3();
-                if (!use_constant_color_) {
-                    C *= .2_f + .8_f*glm::abs(glm::dot(sp->geom.n, -ray.d));
+                if (sp->geom.infinite) {
+                    // Hit against environment light
+                    const auto& primitive = scene_->node_at(sp->primitive).primitive;
+                    const auto Le =  primitive.light->eval(sp->geom, sp->geom.wo, false);
+                    film_->set_pixel(x, y, Le);
                 }
-                film_->set_pixel(x, y, C);
+                else {
+                    const auto R = color_ ? *color_ : path::reflectance(scene_ , *sp);
+                    auto C = R ? *R : Vec3();
+                    if (!use_constant_color_) {
+                        C *= .2_f + .8_f*glm::abs(glm::dot(sp->geom.n, -ray.d));
+                    }
+                    film_->set_pixel(x, y, C);
+                }
             }
         });
 


### PR DESCRIPTION
This PR fixed the follow bugs:

- In `objloader::simple`, we fixed a bug that an empty primitive was created when 'usemtl' and 'g' are both included in the .obj file.
- In `renderer::raycast`, we added handling of environment light.